### PR TITLE
fix: favicon.ico 404エラーを修正

### DIFF
--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#000000"/>
+  <text x="16" y="22" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="#ffffff">H</text>
+</svg>

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -6,7 +6,8 @@ export default function Document() {
       <Head>
         <meta name="description" content="Hol1kgmgTechBlog - 技術的な知見や経験を共有するブログ" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link rel="alternate icon" href="/favicon.ico" />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Summary
favicon.icoファイルが存在しないため発生していた404エラーを修正

## Changes
- 空のfavicon.icoファイルを追加（ブラウザの互換性のため）
- SVG形式のfaviconを作成（黒背景に白文字の"H"）
- _document.tsxでfavicon設定を更新
  - SVG形式を優先的に使用
  - favicon.icoをフォールバックとして設定

## Test plan
- [x] ブラウザのコンソールで404エラーが表示されないことを確認
- [x] ブラウザのタブにfaviconが表示されることを確認
- [x] 各ページでfaviconが正しく表示されることを確認

Fixes #1
